### PR TITLE
fix ERA5Land preprocessing

### DIFF
--- a/regions/Switzerland/1.2. ERA5Land-prepro.ipynb
+++ b/regions/Switzerland/1.2. ERA5Land-prepro.ipynb
@@ -19,7 +19,6 @@
     "from tqdm.notebook import tqdm\n",
     "import zipfile\n",
     "import cdsapi\n",
-    "import zipfile\n",
     "import numpy as np\n",
     "import glob\n",
     "import xarray as xr\n",
@@ -187,7 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! ls '../../../data/ERA5Land/raw/'"
+    "! ls \"{path_ERA5_raw}\""
    ]
   },
   {
@@ -196,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xr.open_dataset(path_ERA5_raw+'data_0.nc')"
+    "dc=xr.open_dataset(path_ERA5_raw+'data_stream-moda.nc')"
    ]
   },
   {
@@ -205,9 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dcs = []\n",
-    "for path in glob.glob(path_ERA5_raw+'*.nc'):\n",
-    "    dcs.append(xr.open_dataset(path))"
+    "dc2 = dc.rename({'valid_time': 'time'}) # Coordinates have changed recently in the API, this is to keep compatibility with our code"
    ]
   },
   {
@@ -216,83 +213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coordsVar = []\n",
-    "dataVar = []\n",
-    "for dc in dcs:\n",
-    "    coordsVar += list(dc.coords)\n",
-    "    dataVar += list(dc.data_vars)\n",
-    "coordsVar = np.unique(coordsVar).tolist()\n",
-    "dataVar = np.unique(dataVar).tolist()\n",
-    "print(f\"{coordsVar=}\")\n",
-    "print(f\"{dataVar=}\")\n",
-    "\n",
-    "coords = {k:[] for k in coordsVar}\n",
-    "dataTypes = {}\n",
-    "for dc in dcs:\n",
-    "    for k in dc.coords:\n",
-    "        if len(dc[k].shape)>0:\n",
-    "            coords[k] +=  list(dc[k].values)\n",
-    "    for k in dc.data_vars:\n",
-    "        if k not in dataTypes:\n",
-    "            dataTypes[k] = dc[k].dtype\n",
-    "coords = {k: np.sort(np.unique(np.array(coords[k]))) for k in coords}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "discardVar = ['expver']\n",
-    "\n",
-    "size = tuple(len(coords[k]) for k in coords if len(coords[k])>0)\n",
-    "print(f\"{size=}\")\n",
-    "dims = tuple(k for k in coords if len(coords[k])>0 and k not in discardVar)\n",
-    "print(f\"{dims=}\")\n",
-    "data = {}\n",
-    "for k in dataVar:\n",
-    "    data[k] = np.zeros(size, dtype=dataTypes[k])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for e, dc in enumerate(dcs):\n",
-    "    print(f\"Processing datacube n°{e} / {len(dcs)}\")\n",
-    "    for k in tqdm(dc.data_vars):\n",
-    "        idx = []\n",
-    "        selVar = []\n",
-    "        for c in dims+tuple(discardVar):\n",
-    "            if len(dc[c].shape)>0 and c not in discardVar:\n",
-    "                s = list(dc[c].values)\n",
-    "                sorter = np.argsort(coords[c])\n",
-    "                tmp = sorter[np.searchsorted(coords[c], s, sorter=sorter)]\n",
-    "                idx.append(tmp)\n",
-    "            elif c in discardVar:\n",
-    "                s = list(dc[c].values)\n",
-    "                sorter = np.argsort(coords[c])\n",
-    "                tmp = sorter[np.searchsorted(coords[c], s, sorter=sorter)]\n",
-    "                selVar.append(tmp)\n",
-    "        assert len(selVar)==1\n",
-    "        for v in selVar[0]:\n",
-    "            data[k][v][idx[0],:,:][:,idx[1],:][:,:,idx[2]] = dc[k].data.transpose((1,2,0))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.Dataset(\n",
-    "    {k: (tuple(discardVar)+dims, data[k]) for k in data},\n",
-    "    coords=coords\n",
-    ")\n",
-    "ds.to_netcdf(path_ERA5_raw+\"era5_monthly_averaged_data.nc\")"
+    "dc2.to_netcdf(path_ERA5_raw+\"era5_monthly_averaged_data.nc\")"
    ]
   },
   {
@@ -319,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.0"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
The format of the files returned by the API has changed. The purpose of this PR is to fix this.
There are two changes:
- The netcdf files are merged together and we don't have to worry about doing this by hand.
- The entry `time` has changed and it is now named `valid_time`. In the notebook we rename it to remain compatible with the code.